### PR TITLE
Change the vendor name from "LastFm" to "Dandelionmood".

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Once it's done, here's how you get an instance to work with :
 
 ```php
 // The secret is only needed if you want to access authenticated methods
-$lastfm = new \LastFm\LastFm( $lastfm_api_key, $lastfm_api_secret );
+$lastfm = new \Dandelionmood\LastFm\LastFm( $lastfm_api_key, $lastfm_api_secret );
 ```
 
 Now let's say you want to get info on a given artist ? If you look into the

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	},
 	"autoload": {
 		"psr-0": {
-			"LastFm": "lib/Dandelionmood/"
+			"Dandelionmood": "lib"
 		}
 	}
 }

--- a/examples/authentication.php
+++ b/examples/authentication.php
@@ -7,7 +7,7 @@
 	* containing the API key and secret to make it work.
 */
 
-use \LastFm\LastFm;
+use \Dandelionmood\LastFm\LastFm;
 use \Slim\Slim;
 
 $app = new Slim();

--- a/lib/Dandelionmood/LastFm/LastFm.php
+++ b/lib/Dandelionmood/LastFm/LastFm.php
@@ -1,5 +1,5 @@
 <?php
-namespace LastFm;
+namespace Dandelionmood\LastFm;
 
 use \Buzz\Browser;
 

--- a/tests/LastFmTest.php
+++ b/tests/LastFmTest.php
@@ -1,5 +1,5 @@
 <?php
-use \LastFm\LastFm;
+use \Dandelionmood\LastFm\LastFm;
 
 /**
 	* A simple test to see if the minimum is working


### PR DESCRIPTION
Hullo,

The LastFm (or Lastfm) vendor name should be reserved for Last.fm. I've changed all instances of `\LastFm\LastFm` to `\Dandelionmood\LastFm\LastFm` to avoid any confusion.
