### PR TITLE
Never buzz version(s)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	],
 	"require": {
 		"php": ">=5.3.0",
-		"kriswallsmith/buzz": "v0.9"
+		"kriswallsmith/buzz": ">=0.9"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "3.7.18",


### PR DESCRIPTION
I tested php-lastfm with buzz until v0.12 and it works well - with this small change I was able to use it with other libraries, that need buzz with a version >=0.12.
