### PR TITLE
Update LastFm.php

### DIFF
--- a/lib/Dandelionmood/LastFm/LastFm.php
+++ b/lib/Dandelionmood/LastFm/LastFm.php
@@ -147,7 +147,7 @@ class LastFm
 		$browser = new Browser();
 		$response = $browser->post(
 			self::API_URL,
-			array(),
+			array("Content-type" =>  "Content-type: application/x-www-form-urlencoded"),
 			http_build_query( $parameters )
 		);
 		$json = json_decode( $response->getContent() );


### PR DESCRIPTION
prevents Buzz\Client\FileGetContents.php from producing the warning "file_get_contents(): Content-type not specified assuming application/x-www-form-urlencoded"
