### PR TITLE
Check für NULL instead of false

### DIFF
--- a/lib/Dandelionmood/LastFm/LastFm.php
+++ b/lib/Dandelionmood/LastFm/LastFm.php
@@ -153,7 +153,7 @@ class LastFm
 		$json = json_decode( $response->getContent() );
 		
 		// The JSON couldn't be decoded …
-		if( $json === false )
+		if( $json === NULL )
 			throw new \Exception("JSON response seems incorrect.");
 		
 		// An error has occurred …


### PR DESCRIPTION
json_decode returns NULL when it can't decode the string.
http://php.net/manual/en/function.json-decode.php