### PR TITLE
Change the properties from protected to private.

### DIFF
--- a/lib/Dandelionmood/LastFm/LastFm.php
+++ b/lib/Dandelionmood/LastFm/LastFm.php
@@ -19,9 +19,9 @@ use \Buzz\Browser;
 */
 class LastFm
 {
-	private $_api_key = null;
-	private $_api_secret = null;
-	private $_session_key = null;
+	protected $_api_key = null;
+	protected $_api_secret = null;
+	protected $_session_key = null;
 	
 	const API_URL = 'http://ws.audioscrobbler.com/2.0/';
 	const AUTH_URL = 'http://www.last.fm/api/auth/';


### PR DESCRIPTION
This way, classes who inherit from LastFm can access the keys.